### PR TITLE
Bewerted Version

### DIFF
--- a/ModSimWS1718Uebung03LeoPichler.ipynb
+++ b/ModSimWS1718Uebung03LeoPichler.ipynb
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Float sind Kommazahlen nur Annäherungen. Dementsprechend benutzt das Programm die beste Annäherung an die einzelnen Nachkommastellen bis zur kleinstmöglichen Annäherung und entscheidet sich ab da, ob die unmittelbar größere Zahl oder eben die unmittelbar kleinere näher an der eigentlichen Zahl liegt. Da bei beiden Zahlen das Programm die unmittelbar größere Annäherung bevorzugt, ist die resultierende Zahl nicht mehr die kleinste Annäherung an das eigentliche Ergebnis."
+    "In Float sind Kommazahlen nur Annäherungen. Dementsprechend benutzt das Programm die beste Annäherung an die einzelnen Nachkommastellen bis zur kleinstmöglichen Annäherung und entscheidet sich ab da, ob die unmittelbar größere Zahl oder eben die unmittelbar kleinere näher an der eigentlichen Zahl liegt. Da bei beiden Zahlen das Programm die unmittelbar größere Annäherung bevorzugt, ist die resultierende Zahl nicht mehr die kleinste Annäherung an das eigentliche Ergebnis. #sehen Commit Nachricht"
    ]
   },
   {


### PR DESCRIPTION
Af3. "Da bei beiden Zahlen das Programm die unmittelbar größere Annäherung bevorzugt..."
Stimmt leider nicht. Da z.B print("number %.20f" %(1.+.3)) ergibt sich 1.30000000000000004441, aber print("number %.20f" %(1.4+.2)) ergibt sich 1.59999999999999986677. Also manchmal ist es größer als die wahre Ergebnisse, manchmal kleiner. (-3)